### PR TITLE
render json response as json

### DIFF
--- a/app/controllers/kapnismology/smoke_tests_controller.rb
+++ b/app/controllers/kapnismology/smoke_tests_controller.rb
@@ -4,7 +4,7 @@ module Kapnismology
   class SmokeTestsController < ApplicationController
     def index
       evaluations = SmokeTestCollection.evaluations(allowed_tags, blacklist)
-      render text: evaluations.to_json, status: status(evaluations)
+      render json: evaluations.to_json, status: status(evaluations)
     end
 
     private


### PR DESCRIPTION
solves deprecation warnings about using "render :text" and makes it more consistent