### PR TITLE
coloring only on tty ouput

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 2.0.3
+* Coloring output only on interactive terminals
+
 # 2.0.2
 * Make sure the internal @all\_result\_messages array is initialized
 

--- a/lib/kapnismology/terminal.rb
+++ b/lib/kapnismology/terminal.rb
@@ -1,20 +1,25 @@
 module Kapnismology
   class Terminal
-
     def self.green(msg)
-      "\e[32m\e[1m#{msg}\e[0m"
+      colorize(msg, "\e[32m")
     end
 
     def self.red(msg)
-      "\e[31m\e[1m#{msg}\e[0m"
+      colorize(msg, "\e[31m")
     end
 
     def self.yellow(msg)
-      "\e[33m\e[1m#{msg}\e[0m"
+      colorize(msg, "\e[33m")
     end
 
     def self.bold(msg)
-      "\e[1m#{msg}\e[0m"
+      colorize(msg, '')
+    end
+
+    private
+    def self.colorize(msg, color_code)
+      # \e[1m adds bold font, \e[0m resets all styles
+      $stdout.isatty ? "#{color_code}\e[1m#{msg}\e[0m" : msg
     end
   end
 end

--- a/lib/kapnismology/version.rb
+++ b/lib/kapnismology/version.rb
@@ -1,3 +1,3 @@
 module Kapnismology
-  VERSION = '2.0.2'.freeze
+  VERSION = '2.0.3'.freeze
 end


### PR DESCRIPTION

This is more a bug than a feature, on non-tty terminals the colors may not be recognized making for the ugliest output, this should solve the problem

@jfeltesse-mdsol @ykitamura-mdsol 