### PR TITLE
Only load Kapnismology engine when Rails is defined

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,4 +19,6 @@ gemfile:
   - gemfiles/rails_42.gemfile
   - gemfiles/rails_50.gemfile
 
-script: bundle exec rspec
+script:
+  - NO_RAILS=1 bundle exec rspec
+  - bundle exec rspec

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 2.2.0
+* Only load Kapnismology engine when Rails is defined
+* Support running unit tests without Rails with `NO_RAILS=1 bundle exec rspec`
+
 # 2.1.0
 * Output has codebase revision information
 
@@ -15,13 +19,11 @@
 * Removed InfoResult class
 
 # 1.12
-* Added timeout functionality. Now smoke tests timeout after 10s by
-  default.
+* Added timeout functionality. Now smoke tests timeout after 10s by default.
 * Rescue exceptions inheriting from Exception to rescue network errors
 
 # 1.11
-* Added a class NotApplicableResult for the cases when we really really
-  do not want to show a result in the output
+* Added a class NotApplicableResult for the cases when we really really do not want to show a result in the output
 
 # 1.10
 * Added a class InfoResult to substitute NullResult (which is deprecated now)
@@ -31,8 +33,7 @@
 * SmokeTestFailed accepts an exception as parameter
 
 # 1.8.2
-* Allow to see message, data and extra_messages to make for painless
-  testing
+* Allow to see message, data and extra_messages to make for painless testing
 
 # 1.8.1
 * Allow to raise SmokeTestFailed from outside smoketest classes
@@ -68,11 +69,9 @@
 * Allows to provide a "skip" parameted to the url to skip certain smoke tests
 
 # 1.0.0
-* Output uses "data" to indicate data, the test name is the key of the
-  hash.
+* Output uses "data" to indicate data, the test name is the key of the hash.
 * Order of parameters in the Result API has changed to make more sense.
-* Classes do not need to specify their name. They still can but it is
-  optional
+* Classes do not need to specify their name. They still can but it is optional
 
 # 0.1.2
 * Add tests for rails 3.2, 4.0, 4.1, 4.2

--- a/README.md
+++ b/README.md
@@ -210,6 +210,18 @@ Usage:
 
 `result` will be processed so you do not need to deal with the internals of Kapnismology but just check the properties of a Result object
 
+## Unit Tests
+
+Run the Kapnismology unit tests with the command:
+```
+bundle exec rspec
+```
+
+To verify that Kapnismology also runs properly in non-Rails applications, run the following:
+```
+NO_RAILS=1 bundle exec rspec
+```
+
 ## TODO
 
 - Automount routes

--- a/kapnismology.gemspec
+++ b/kapnismology.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.files = Dir['{app,config,lib}/**/*', 'Rakefile', 'README.md']
   s.test_files = Dir['test/**/*']
 
-  s.add_dependency 'rails', '>= 3.2.13'
+  s.add_development_dependency 'rails', '>= 3.2.13'
   s.add_development_dependency 'rspec', '~> 3.4'
   s.add_development_dependency 'byebug', '~> 9.0'
   s.add_development_dependency 'mutant', '~> 0.8'

--- a/lib/kapnismology/engine.rb
+++ b/lib/kapnismology/engine.rb
@@ -1,31 +1,33 @@
 # Rails support, this may need changes if Rails change internals
-module Kapnismology
-  begin
-    # Rails engine to automatically load our code and smoke tests libraries
-    class Engine < ::Rails::Engine
-      initializer 'kapnismology.add_autoload_paths', before: :set_autoload_paths do |_app|
-        smoketest_dir = Rails.root.join('lib', 'smoke_test')
-        if smoketest_dir.exist?
-          Dir[File.join(smoketest_dir, '*.rb')].each { |file| require file }
+if defined?(Rails)
+  module Kapnismology
+    begin
+      # Rails engine to automatically load our code and smoke tests libraries
+      class Engine < ::Rails::Engine
+        initializer 'kapnismology.add_autoload_paths', before: :set_autoload_paths do |_app|
+          smoketest_dir = Rails.root.join('lib', 'smoke_test')
+          if smoketest_dir.exist?
+            Dir[File.join(smoketest_dir, '*.rb')].each { |file| require file }
+          end
         end
+
+        isolate_namespace Kapnismology
       end
 
-      isolate_namespace Kapnismology
-    end
-
-    # Inserts the engine (the smoketest_controller) into a given path.
-    # TODO: how to automatically do this without the user needing to insert?
-    class Routes
-      def self.insert!(path)
-        if defined?(Kapnismology) == false
-          raise 'require kapnismology before trying to insert routes'
-        end
-        Rails.application.routes.draw do
-          mount Kapnismology::Engine, at: path
+      # Inserts the engine (the smoketest_controller) into a given path.
+      # TODO: how to automatically do this without the user needing to insert?
+      class Routes
+        def self.insert!(path)
+          if defined?(Kapnismology) == false
+            raise 'require kapnismology before trying to insert routes'
+          end
+          Rails.application.routes.draw do
+            mount Kapnismology::Engine, at: path
+          end
         end
       end
+    rescue NameError => e
+      puts "Incompatible Rails version #{e}"
     end
-  rescue NameError => e
-    puts "Incompatible Rails version #{e}"
   end
 end

--- a/lib/kapnismology/evaluation_collection.rb
+++ b/lib/kapnismology/evaluation_collection.rb
@@ -20,7 +20,7 @@ module Kapnismology
     end
 
     def to_json
-      evaluations.to_json
+      evaluations.map { |evaluation| evaluation.as_json }.to_json
     end
 
     private

--- a/lib/kapnismology/version.rb
+++ b/lib/kapnismology/version.rb
@@ -1,3 +1,3 @@
 module Kapnismology
-  VERSION = '2.1.0'.freeze
+  VERSION = '2.2.0'.freeze
 end

--- a/spec/features/smoke_test_url_spec.rb
+++ b/spec/features/smoke_test_url_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 module Kapnismology
-  RSpec.feature 'Access to the smoke test API', type: :feature do
+  RSpec.feature 'Access to the smoke test API' do
     let(:data) { { title: 'berserk' } }
     let(:passed) { true }
     let(:message) { '黄金時代' }
@@ -40,7 +40,7 @@ module Kapnismology
       end
     end
 
-    context 'with all the information' do
+    context 'with all the information', :requires_rails do
       before do
         allow_any_instance_of(ApplicationInformation).to receive(:trace_id).and_return(trace_id)
         allow_any_instance_of(ApplicationInformation).to receive(:codebase_revision).and_return(codebase_revision)

--- a/spec/internal/config/routes.rb
+++ b/spec/internal/config/routes.rb
@@ -1,5 +1,7 @@
-require 'kapnismology/engine'
+if defined?(Rails)
+  require 'kapnismology/engine'
 
-Rails.application.routes.draw do
-  mount Kapnismology::Engine, at: '/smoke_test'
+  Rails.application.routes.draw do
+    mount Kapnismology::Engine, at: '/smoke_test'
+  end
 end

--- a/spec/lib/kapnismology/evaluation_collection_spec.rb
+++ b/spec/lib/kapnismology/evaluation_collection_spec.rb
@@ -22,8 +22,8 @@ module Kapnismology
         expect(evaluations.passed?).to eq(true)
       end
       it 'returns a json object' do
-        first  = { name: 'guts', passed:true, data:{ title: 'berserk' }, message: "黄金時代", debug_messages:[]}
-        second  = { name: 'gits', passed:true, data:{ title: 'berserk' }, message: "黄金時代", debug_messages:[]}
+        first  = { name: 'guts', passed: true, data: { title: 'berserk' }, message: "黄金時代", debug_messages: [] }
+        second  = { name: 'gits', passed: true, data: { title: 'berserk' }, message: "黄金時代", debug_messages: [] }
         expected = [first, second].to_json
         expect(evaluations.to_json).to eq(expected)
       end
@@ -41,8 +41,8 @@ module Kapnismology
         expect(evaluations.passed?).to eq(false)
       end
       it 'returns a json object' do
-        first  = { name: 'guts', passed:false, data:{ title: 'berserk' }, message: "黄金時代", debug_messages:[]}
-        second  = { name: 'gits', passed:true, data:{ title: 'berserk' }, message: "黄金時代", debug_messages:[]}
+        first  = { name: 'guts', passed: false, data: { title: 'berserk' }, message: "黄金時代", debug_messages: [] }
+        second  = { name: 'gits', passed: true, data: { title: 'berserk' }, message: "黄金時代", debug_messages: [] }
         expected = [first, second].to_json
         expect(evaluations.to_json).to eq(expected)
       end
@@ -60,7 +60,7 @@ module Kapnismology
         expect(evaluations.passed?).to eq(true)
       end
       it 'returns a json object without data' do
-        first  = { name: 'guts', passed:true, data:{ title: 'berserk' }, message: "黄金時代", debug_messages:[]}
+        first  = { name: 'guts', passed: true, data: { title: 'berserk' }, message: "黄金時代", debug_messages: [] }
         second  = { name: 'gits' }
         expected = [first, second].to_json
         expect(evaluations.to_json).to eq(expected)

--- a/spec/lib/kapnismology/evaluation_spec.rb
+++ b/spec/lib/kapnismology/evaluation_spec.rb
@@ -13,9 +13,9 @@ module Kapnismology
     end
     let(:evaluation) { Evaluation.new(TestSmokeTest) }
 
-    it 'creates a json representation' do
-      expected = '{"name":"test_smoke_test","passed":true,"data":{"title":"berserk"},"message":"黄金時代","debug_messages":[]}'
-      expect(evaluation.to_json).to eq(expected)
+    it 'creates a hash that can be converted to a JSON representation' do
+      expected = { name: 'test_smoke_test', passed: true, data: { title: 'berserk' }, message: "黄金時代", debug_messages: [] }
+      expect(evaluation.as_json).to eq(expected)
     end
 
     it 'knows if the test passed' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,9 +4,10 @@ require 'byebug'
 
 require 'capybara/rspec'
 
-Combustion.initialize! :all
-
-require 'capybara/rails'
+unless ENV['NO_RAILS']
+  Combustion.initialize! :all
+  require 'capybara/rails'
+end
 
 require 'kapnismology'
 require File.expand_path('../support/fake_smoketest', __FILE__)
@@ -24,6 +25,10 @@ RSpec.configure do |config|
   end
 
   config.disable_monkey_patching!
+
+  if ENV['NO_RAILS']
+    config.filter_run_excluding :requires_rails
+  end
 
   config.run_all_when_everything_filtered = true
 


### PR DESCRIPTION
Aside from whitespace changes, wrapping engine.rb in `if defined?(Rails)` is the only real change.

@ykitamura-mdsol @JordiPolo @jfeltesse-mdsol 