### PR TITLE
Measure the processing time of each smoke test and record the result in debug_messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 2.3.0
+* Measure the duration of each smoke test
+
 # 2.2.1
 * Expose the `status` and `render` methods in SmokeTestResponse, so clients can call them directly
 

--- a/kapnismology.gemspec
+++ b/kapnismology.gemspec
@@ -27,4 +27,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'combustion', '~> 0.5.3'
   s.add_development_dependency 'sqlite3', '~> 1.3'
   s.add_development_dependency 'capybara'
+  s.add_development_dependency 'timecop', '~> 0.7'
 end

--- a/lib/kapnismology/evaluation.rb
+++ b/lib/kapnismology/evaluation.rb
@@ -22,5 +22,9 @@ module Kapnismology
       @result.to_s(@name)
     end
 
+    def duration
+      @result.duration
+    end
+
   end
 end

--- a/lib/kapnismology/evaluation_collection.rb
+++ b/lib/kapnismology/evaluation_collection.rb
@@ -23,6 +23,10 @@ module Kapnismology
       evaluations.map(&:to_hash)
     end
 
+    def total_duration
+      evaluations.inject(0) { |total, member| total += member.duration.to_i }
+    end
+
     private
 
     def evaluations

--- a/lib/kapnismology/result.rb
+++ b/lib/kapnismology/result.rb
@@ -3,15 +3,15 @@ module Kapnismology
   # It is useful to be able to test if the object is of a correct result type.
   # It also have methods to add information and serialize it.
   class BaseResult
-    attr_reader :data, :message, :debug_messages
+    attr_reader :data, :message, :debug_messages, :duration
     def to_hash
-      { passed: passed?, data: @data, message: @message, debug_messages: @debug_messages }
+      { passed: passed?, data: @data, message: @message, debug_messages: @debug_messages, duration: @duration }
     end
 
     def to_s(name)
       <<-eos
 #{format_passed(passed?)}: #{name}
-#{format_debug_messages(@debug_messages)}#{Terminal.bold(@message)}
+#{format_duration(@duration)}#{format_debug_messages(@debug_messages)}#{Terminal.bold(@message)}
    #{@data}
 eos
     end
@@ -23,6 +23,10 @@ eos
 
     def passed?
       !!@passed
+    end
+
+    def record_duration(start_time)
+      @duration = ((Time.now - start_time) * 1000).floor
     end
 
     private
@@ -37,6 +41,10 @@ eos
 
     def format_passed(passed)
       passed ? Terminal.green('passed') : Terminal.red('failed')
+    end
+
+    def format_duration(duration)
+      "duration: #{Terminal.bold(duration)} ms\n"
     end
   end
 
@@ -54,6 +62,7 @@ eos
       @data = data
       @message = message
       @debug_messages = []
+      @duration = 0
     end
   end
 
@@ -64,6 +73,7 @@ eos
       @data = data
       @message = message
       @debug_messages = []
+      @duration = 0
     end
 
     def to_s(name)
@@ -97,6 +107,7 @@ eos
       @data = data
       @message = message
       @debug_messages = []
+      @duration = 0
     end
   end
 end

--- a/lib/kapnismology/smoke_test.rb
+++ b/lib/kapnismology/smoke_test.rb
@@ -17,6 +17,7 @@ module Kapnismology
 
     # Internally Kapnismology is calling this method. We are handling exceptions under the hood here
     def __result__
+      start_time = Time.now
       execution = Timeout::timeout(self.class.timeout) { result }
       result_object = execution || Result.new(false, {}, 'This test has not returned any result')
       unless result_object.class.ancestors.include?(BaseResult)
@@ -33,6 +34,7 @@ module Kapnismology
       result_object = Result.new(false, { exception: e.class, message: e.message }, message)
     ensure
       @all_result_messages ||= []
+      result_object.record_duration(start_time)
       return result_object.add_debug_messages(@all_result_messages)
     end
 

--- a/lib/kapnismology/smoke_test_response.rb
+++ b/lib/kapnismology/smoke_test_response.rb
@@ -23,6 +23,7 @@ module Kapnismology
         count: items.size,
         trace_id: ApplicationInformation.new.trace_id,
         codebase_revision: ApplicationInformation.new.codebase_revision,
+        duration: @evaluations.total_duration,
         items: items
       }.to_json
     end

--- a/lib/kapnismology/version.rb
+++ b/lib/kapnismology/version.rb
@@ -1,3 +1,3 @@
 module Kapnismology
-  VERSION = '2.2.1'.freeze
+  VERSION = '2.3.0'.freeze
 end

--- a/spec/features/smoke_test_url_spec.rb
+++ b/spec/features/smoke_test_url_spec.rb
@@ -34,6 +34,7 @@ module Kapnismology
           count: count,
           trace_id: trace_id,
           codebase_revision: codebase_revision,
+          duration: 0,
           items: items
         }.to_json
         expect(page).to have_text(expected)

--- a/spec/lib/kapnismology/evaluation_collection_spec.rb
+++ b/spec/lib/kapnismology/evaluation_collection_spec.rb
@@ -11,6 +11,8 @@ module Kapnismology
     let(:evaluations) { EvaluationCollection.new(smoke_tests) }
     let(:name2) { 'gits' }
 
+    before { Timecop.freeze }
+
     context 'all evaluation passed' do
       before do
         FakeSmokeTest.name = name
@@ -24,8 +26,8 @@ module Kapnismology
       end
 
       it 'returns a hash representation' do
-        first  = { name: 'guts', passed: true, data: { title: 'berserk' }, message: "黄金時代", debug_messages: [] }
-        second  = { name: 'gits', passed: true, data: { title: 'berserk' }, message: "黄金時代", debug_messages: [] }
+        first  = { name: 'guts', passed: true, data: { title: 'berserk' }, message: "黄金時代", debug_messages: [], duration: 0 }
+        second  = { name: 'gits', passed: true, data: { title: 'berserk' }, message: "黄金時代", debug_messages: [], duration: 0 }
         expected = [first, second]
         expect(evaluations.to_hash).to eq(expected)
       end
@@ -45,8 +47,8 @@ module Kapnismology
       end
 
       it 'returns a hash representation' do
-        first  = { name: 'guts', passed: false, data: { title: 'berserk' }, message: "黄金時代", debug_messages: [] }
-        second  = { name: 'gits', passed: true, data: { title: 'berserk' }, message: "黄金時代", debug_messages: [] }
+        first  = { name: 'guts', passed: false, data: { title: 'berserk' }, message: "黄金時代", debug_messages: [], duration: 0 }
+        second  = { name: 'gits', passed: true, data: { title: 'berserk' }, message: "黄金時代", debug_messages: [], duration: 0 }
         expected = [first, second]
         expect(evaluations.to_hash).to eq(expected)
       end
@@ -66,7 +68,7 @@ module Kapnismology
       end
 
       it 'returns a hash representation' do
-        first  = { name: 'guts', passed: true, data: { title: 'berserk' }, message: "黄金時代", debug_messages: [] }
+        first  = { name: 'guts', passed: true, data: { title: 'berserk' }, message: "黄金時代", debug_messages: [], duration: 0 }
         second  = { name: 'gits' }
         expected = [first, second]
         expect(evaluations.to_hash).to eq(expected)

--- a/spec/lib/kapnismology/evaluation_spec.rb
+++ b/spec/lib/kapnismology/evaluation_spec.rb
@@ -12,9 +12,17 @@ module Kapnismology
       end
     end
     let(:evaluation) { Evaluation.new(TestSmokeTest) }
+    before { Timecop.freeze }
 
     it 'creates a hash that can be converted to a JSON representation' do
-      expected = { name: 'test_smoke_test', passed: true, data: { title: 'berserk' }, message: "黄金時代", debug_messages: [] }
+      expected = {
+        name: 'test_smoke_test',
+        passed: true,
+        data: { title: 'berserk' },
+        message: "黄金時代",
+        debug_messages: [],
+        duration: 0
+      }
       expect(evaluation.to_hash).to eq(expected)
     end
 
@@ -23,7 +31,7 @@ module Kapnismology
     end
 
     it 'creates a string representation' do
-      expected = %|#{Terminal.green('passed')}: TestSmokeTest\n\e[1m黄金時代\e[0m\n   {:title=>"berserk"}\n|
+      expected = %|#{Terminal.green('passed')}: TestSmokeTest\nduration: \e[1m0\e[0m ms\n\e[1m黄金時代\e[0m\n   {:title=>"berserk"}\n|
       expect(evaluation.to_s).to eq(expected)
     end
   end

--- a/spec/lib/kapnismology/result_spec.rb
+++ b/spec/lib/kapnismology/result_spec.rb
@@ -10,13 +10,13 @@ RSpec.describe Kapnismology::Result do
 
   shared_examples_for 'serializes its data' do
     it 'creates a string with its data' do
-      first = "\e[#{terminal_color}m\e[1m#{title}\e[0m: #{name}"
+      first = "\e[#{terminal_color}m\e[1m#{title}\e[0m: #{name}\nduration: \e[1m0\e[0m ms"
       expected = "#{first}\n#{debug_messages.join("\n")}#{extra_char}\e[1m#{message}\e[0m\n   #{data}\n"
       expect(result.to_s(name)).to eq(expected)
     end
 
     it 'creates a hash with its data' do
-      expected = { passed: passed, data: data, message: message, debug_messages: debug_messages }
+      expected = { passed: passed, data: data, message: message, debug_messages: debug_messages, duration: 0 }
       expect(result.to_hash).to eq(expected)
     end
   end
@@ -33,6 +33,17 @@ RSpec.describe Kapnismology::Result do
 
   it 'provides access to passed status' do
     expect(result.passed?).to eq(passed)
+  end
+
+  describe 'record_duration' do
+    before do
+      Timecop.freeze
+    end
+
+    it 'records duration of the test' do
+      result.record_duration(Time.now - 1)
+      expect(result.duration).to eq(1000)
+    end
   end
 
   describe 'output' do
@@ -120,7 +131,7 @@ RSpec.describe Kapnismology::NullResult do
   end
 
   it "#{described_class}#to_s shows a skipped check" do
-    first = "\e[33m\e[1mThis test can not be run. Skipping...\e[0m\n\e[33m\e[1mSkipped\e[0m: #{name}"
+    first = "\e[33m\e[1mThis test can not be run. Skipping...\e[0m\n\e[33m\e[1mSkipped\e[0m: #{name}\nduration: \e[1m0\e[0m ms"
     expected = "#{first}\n#{[].join("\n")}\e[1m#{message}\e[0m\n   #{data}\n"
     expect(result.to_s(name)).to eq(expected)
   end

--- a/spec/lib/kapnismology/smoke_test_response_spec.rb
+++ b/spec/lib/kapnismology/smoke_test_response_spec.rb
@@ -14,6 +14,10 @@ module Kapnismology
     let(:profile_url) { 'http://tbd.mdsol.com' }
     let(:name2) { 'gits' }
 
+    before do
+      allow_any_instance_of(Result).to receive(:duration).and_return(123)
+    end
+
     context 'all evaluations passed' do
       let(:first) { { name: 'guts', passed: true, data: { title: 'berserk' }, message: "黄金時代", debug_messages: [] } }
       let(:second) { { name: 'gits', passed: true, data: { title: 'berserk' }, message: "黄金時代", debug_messages: [] } }
@@ -28,11 +32,12 @@ module Kapnismology
         expect(run.status).to eq(200)
       end
 
-      it '#render includes the smoke test count and items, links and passed status' do
+      it '#render includes the smoke test count and items, links, duration and passed status' do
         expect(run.render(request_url)).to include_json(
           _links: { self: request_url, profile: profile_url },
           passed: true,
           count: 2,
+          duration: 246,
           items: [first, second]
         )
       end
@@ -53,11 +58,12 @@ module Kapnismology
         expect(run.status).to eq(503)
       end
 
-      it '#render includes the smoke test count and items, links and passed status' do
+      it '#render includes the smoke test count and items, links, duration and passed status' do
         expect(run.render(request_url)).to include_json(
           _links: { self: request_url, profile: profile_url },
           passed: false,
           count: 2,
+          duration: 246,
           items: [first, second]
         )
       end
@@ -78,11 +84,12 @@ module Kapnismology
         expect(run.status).to eq(200)
       end
 
-      it '#render includes the smoke test count and items, links and passed status' do
+      it '#render includes the smoke test count and items, links, duration and passed status' do
         expect(run.render(request_url)).to include_json(
           _links: { self: request_url, profile: profile_url },
           passed: true,
           count: 1,
+          duration: 123,
           items: [first]
         )
       end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -11,6 +11,7 @@ unless ENV['NO_RAILS']
 end
 
 require 'kapnismology'
+require 'timecop'
 require File.expand_path('../support/fake_smoketest', __FILE__)
 
 RSpec.configure do |config|
@@ -40,4 +41,6 @@ RSpec.configure do |config|
   config.order = :random
 
   Kernel.srand config.seed
+
+  config.after { Timecop.return }
 end


### PR DESCRIPTION
Record the processing time in `debug_messages`

It will show up like this on rake task:
<img width="218" alt="screen shot 2016-11-04 at 4 05 30 pm" src="https://cloud.githubusercontent.com/assets/16286071/19997274/a060e64e-a2a8-11e6-9b3a-f33e089bf070.png">

@jfeltesse-mdsol @jcarres-mdsol @cabbott @ssteeg-mdsol 