### PR TITLE
Require 'timeout' in SmokeTest class

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,14 +3,16 @@ cache: bundler
 sudo: false
 
 rvm:
-  - 2.1.8
-  - 2.2.4
-  - 2.3.0
+  - 2.2.8
+  - 2.3.5
+  - 2.4.2
 
 matrix:
   exclude:
-    - rvm: 2.1.8
-      gemfile: gemfiles/rails_50.gemfile
+    - rvm: 2.4.2
+      gemfile: gemfiles/rails_40.gemfile
+    - rvm: 2.4.2
+      gemfile: gemfiles/rails_41.gemfile
 
 gemfile:
   - gemfiles/rails_32.gemfile
@@ -18,6 +20,7 @@ gemfile:
   - gemfiles/rails_41.gemfile
   - gemfiles/rails_42.gemfile
   - gemfiles/rails_50.gemfile
+  - gemfiles/rails_51.gemfile
 
 script:
   - NO_RAILS=1 bundle exec rspec

--- a/Appraisals
+++ b/Appraisals
@@ -1,5 +1,5 @@
 appraise "rails-32" do
-  gem "rails", "3.2.13"
+  gem "rails", "3.2.22.5"
 end
 
 appraise "rails-40" do
@@ -7,13 +7,17 @@ appraise "rails-40" do
 end
 
 appraise "rails-41" do
-  gem "rails", "4.1.15"
+  gem "rails", "4.1.16"
 end
 
 appraise "rails-42" do
-  gem "rails", "4.2.6"
+  gem "rails", "4.2.10"
 end
 
 appraise "rails-50" do
-  gem "rails", "5.0.0"
+  gem "rails", "5.0.6"
+end
+
+appraise "rails-51" do
+  gem "rails", "5.1.4"
 end

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 2.3.2
+* Require 'timeout' in SmokeTest class
+
 # 2.3.1
 * The gem depends on Ruby 2.1 or superior.
 

--- a/gemfiles/rails_32.gemfile
+++ b/gemfiles/rails_32.gemfile
@@ -2,6 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "rails", "3.2.22"
+gem "rails", "3.2.22.5"
 
-gemspec :path => "../"
+gemspec path: "../"

--- a/gemfiles/rails_40.gemfile
+++ b/gemfiles/rails_40.gemfile
@@ -4,4 +4,4 @@ source "https://rubygems.org"
 
 gem "rails", "4.0.13"
 
-gemspec :path => "../"
+gemspec path: "../"

--- a/gemfiles/rails_41.gemfile
+++ b/gemfiles/rails_41.gemfile
@@ -2,6 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "rails", "4.1.15"
+gem "rails", "4.1.16"
 
-gemspec :path => "../"
+gemspec path: "../"

--- a/gemfiles/rails_42.gemfile
+++ b/gemfiles/rails_42.gemfile
@@ -2,6 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "rails", "4.2.6"
+gem "rails", "4.2.10"
 
-gemspec :path => "../"
+gemspec path: "../"

--- a/gemfiles/rails_51.gemfile
+++ b/gemfiles/rails_51.gemfile
@@ -2,6 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "rails", "5.0.6"
+gem "rails", "5.1.4"
 
 gemspec path: "../"

--- a/lib/kapnismology/smoke_test.rb
+++ b/lib/kapnismology/smoke_test.rb
@@ -1,3 +1,4 @@
+require 'timeout'
 require 'kapnismology/result'
 require 'kapnismology/smoke_test_collection'
 require 'kapnismology/smoke_test_failed'

--- a/lib/kapnismology/version.rb
+++ b/lib/kapnismology/version.rb
@@ -1,3 +1,3 @@
 module Kapnismology
-  VERSION = '2.3.1'.freeze
+  VERSION = '2.3.2'.freeze
 end

--- a/spec/features/smoke_test_url_spec.rb
+++ b/spec/features/smoke_test_url_spec.rb
@@ -16,6 +16,8 @@ module Kapnismology
     } }
     let(:items) { [ { name: name }.merge(result.to_hash) ] }
     before do
+      Timecop.freeze
+      
       FakeSmokeTest.name = name
       FakeSmokeTest.result = result
       FakeSmokeTest.tags = ['runtime']

--- a/spec/lib/kapnismology/smoke_test_spec.rb
+++ b/spec/lib/kapnismology/smoke_test_spec.rb
@@ -33,11 +33,11 @@ RSpec.describe Kapnismology::SmokeTest do
 
   context 'smoke test returns a class that is not a result' do
     before do
-      allow(smoke_test).to receive(:result).and_return(3)
+      allow(smoke_test).to receive(:result).and_return('pass')
     end
     it 'reports a failed result' do
-      message = 'Smoke test Kapnismology::SmokeTest, returned Fixnum instead of a Result'
-      expect_failed({ returned_class: Fixnum }, message)
+      message = 'Smoke test Kapnismology::SmokeTest, returned String instead of a Result'
+      expect_failed({ returned_class: String }, message)
     end
   end
 


### PR DESCRIPTION
Specify requiring 'timeout' in SmokeTest class to not raise the following error on Travis CI when using this gem with Rails3.2, 4.0 and 4.1:

```
# NameError:
#   uninitialized constant Kapnismology::SmokeTest::Timeout
#   ./gemfiles/vendor/bundle/ruby/2.2.0/gems/kapnismology-2.3.1/lib/kapnismology/smoke_test.rb:21:in `__result__'
```

@jfeltesse-mdsol @jcarres-mdsol @cabbott @ssteeg-mdsol 